### PR TITLE
310-continuous-draws-fix

### DIFF
--- a/R/outcome_class.R
+++ b/R/outcome_class.R
@@ -92,7 +92,6 @@ setClass(
 #' @slot baseline_prior `Prior`. Object of class `Prior`
 #' specifying prior distribution for the baseline outcome.
 #' @slot name_beta_trt. Named vector for beta_trt.
-#' @slot name_exp_trt. Named vector for exponentiated beta_trt
 #' @slot alpha_type. How to interpret alpha.
 #' @slot name_addnl_params. Named vector for additional parameters.
 #' @family outcome
@@ -114,7 +113,6 @@ setClass(
     weight_var = "",
     baseline_prior = NULL,
     name_beta_trt = c("treatment effect" = "beta_trt"),
-    name_exp_trt = c("exponentiated treatment effect" = "beta_trt"),
     alpha_type = "intercept",
     name_addnl_params = NULL
   ),

--- a/R/outcome_cont_normal.R
+++ b/R/outcome_cont_normal.R
@@ -12,7 +12,6 @@
 #' @slot baseline_prior `Prior`. Object of class `Prior`
 #' specifying prior distribution for the baseline outcome.
 #' @slot name_beta_trt. Named vector for beta_trt.
-#' @slot name_exp_trt. Named vector for exponentiated beta_trt
 #' @slot alpha_type. How to interpret alpha.
 #' @slot name_addnl_params. Named vector for additional parameters.
 #' @include outcome_class.R helpers.R prior_half_cauchy.R
@@ -37,26 +36,21 @@
 
 #' Normal Outcome Distribution
 #'
-#' @param continuous_var character. Name of continuous outcome variable in the
-#' model matrix
+#' @param continuous_var character. Name of continuous outcome variable in the model matrix
 #' @param weight_var character. Optional name of variable in model matrix for weighting the log likelihood.
-#' @param baseline_prior `Prior`. Object of class `Prior`
-#' specifying prior distribution for the baseline outcome.
-#' See `Details` for more information.
-#' @param std_dev_prior `Prior`. Object of class `Prior`
-#' specifying prior distribution for the standard deviation of the outcome distribution (i.e. "sigma").
+#' @param baseline_prior `Prior`. Object of class `Prior` specifying prior distribution for the baseline outcome. See
+#'   `Details` for more information.
+#' @param std_dev_prior `Prior`. Object of class `Prior` specifying prior distribution for the standard deviation of the
+#'   outcome distribution (i.e. "sigma").
 #'
-#' @details
-#' ## Baseline Prior
+#' @details ## Baseline Prior
 #'
-#' The `baseline_prior` argument specifies the prior distribution for the
-#' intercept of the linear model. The interpretation of the `baseline_prior` differs
-#' slightly between borrowing methods selected.
-#' - \emph{Dynamic borrowing using `borrowing_hierarchical_commensurate()`}: the `baseline_prior` for Bayesian Dynamic Borrowing
-#' refers to the intercept of the external control arm.
-#' - \emph{Full borrowing} or \emph{No borrowing} using `borrowing_full()` or `borrowing_none()`: the `baseline_prior` for
-#' these borrowing methods refers to the intercept for the
-#' internal control arm.
+#' The `baseline_prior` argument specifies the prior distribution for the intercept of the linear model. The
+#' interpretation of the `baseline_prior` differs slightly between borrowing methods selected.
+#' - \emph{Dynamic borrowing using `borrowing_hierarchical_commensurate()`}: the `baseline_prior` for
+#' Bayesian Dynamic Borrowing refers to the intercept of the external control arm.
+#' - \emph{Full borrowing} or \emph{No borrowing} using `borrowing_full()` or `borrowing_none()`: the
+#' `baseline_prior` for these borrowing methods refers to the intercept for the internal control arm.
 #'
 #' @return Object of class [`OutcomeContinuousNormal`][OutcomeContinuousNormal-class].
 #' @export

--- a/inst/stan/cont/gauss_hcp.stan
+++ b/inst/stan/cont/gauss_hcp.stan
@@ -6,7 +6,7 @@ data {
   int<lower=0> N;                // number of observations
   vector[N] trt;                 // treatment indicator
   array[N] real y;               // outcome
-
+  matrix[N,2] Z;                 // external flag indicators
   {{ weights.data }}
   {{ cov.data }}
 
@@ -16,26 +16,28 @@ parameters {
 
   real beta_trt;                 // treatment effect
   real<lower=0> std_dev_outcome; // standard deviation of outcome
-  real alpha;                    // baseline mean
-
+  vector[2] alpha;               // baseline mean
+  real<lower=0> tau;             // precision on dynamic borrowing
   {{ cov.parameters }}
 
 }
 
 model {
-  
+
   vector[N] lp;
-  
+  real sigma;
+
   {{ trt.prior }}
   {{ cov.priors }}
   {{ baseline.prior }}
   {{ stdev.prior }}
+  {{ tau.prior }}
 
   sigma = 1 / tau;
   alpha[1] ~ normal(alpha[2], sqrt(sigma));
 
   lp = Z * alpha + trt * beta_trt {{ cov.linpred }} ;
-  
+
   for (i in 1:N) {
     target += normal_lupdf(y[i] | lp[i], std_dev_outcome) {{ weights.likelihood }};
   }

--- a/inst/stan/cont/gauss_nb.stan
+++ b/inst/stan/cont/gauss_nb.stan
@@ -2,11 +2,10 @@
 // Hierarchical commensurate prior
 
 data {
-  
+
   int<lower=0> N;                // number of observations
   vector[N] trt;                 // treatment indicator
   array[N] real y;               // outcome
-  matrix[N,2] Z;                 // external flag indicators
 
   {{ weights.data }}
   {{ cov.data }}
@@ -16,25 +15,23 @@ data {
 parameters {
 
   real beta_trt;                 // treatment effect
-  real alpha[2];                 // baseline mean
-  real<lower=0> tau;             // precision on dynamic borrowing
+  real alpha;                    // baseline mean
   real<lower=0> std_dev_outcome; // standard deviation of outcome
 
   {{ cov.parameters }}
-  
+
 }
 
 model {
-  
   vector[N] lp;
-  
+
   {{ trt.prior }}
   {{ cov.priors }}
   {{ baseline.prior }}
   {{ stdev.prior }}
 
-  lp = Z * alpha + trt * beta_trt {{ cov.linpred }} ;
-  
+  lp = alpha + trt * beta_trt {{ cov.linpred }} ;
+
   for (i in 1:N) {
     target += normal_lupdf(y[i] | lp[i], std_dev_outcome) {{ weights.likelihood }};
   }

--- a/man/ContinuousOutcome-class.Rd
+++ b/man/ContinuousOutcome-class.Rd
@@ -21,8 +21,6 @@ specifying prior distribution for the baseline outcome.}
 
 \item{\code{name_beta_trt.}}{Named vector for beta_trt.}
 
-\item{\code{name_exp_trt.}}{Named vector for exponentiated beta_trt}
-
 \item{\code{alpha_type.}}{How to interpret alpha.}
 
 \item{\code{name_addnl_params.}}{Named vector for additional parameters.}

--- a/man/OutcomeContinuousNormal-class.Rd
+++ b/man/OutcomeContinuousNormal-class.Rd
@@ -26,8 +26,6 @@ specifying prior distribution for the baseline outcome.}
 
 \item{\code{name_beta_trt.}}{Named vector for beta_trt.}
 
-\item{\code{name_exp_trt.}}{Named vector for exponentiated beta_trt}
-
 \item{\code{alpha_type.}}{How to interpret alpha.}
 
 \item{\code{name_addnl_params.}}{Named vector for additional parameters.}

--- a/man/outcome_cont_normal.Rd
+++ b/man/outcome_cont_normal.Rd
@@ -12,15 +12,13 @@ outcome_cont_normal(
 )
 }
 \arguments{
-\item{continuous_var}{character. Name of continuous outcome variable in the
-model matrix}
+\item{continuous_var}{character. Name of continuous outcome variable in the model matrix}
 
-\item{baseline_prior}{\code{Prior}. Object of class \code{Prior}
-specifying prior distribution for the baseline outcome.
-See \code{Details} for more information.}
+\item{baseline_prior}{\code{Prior}. Object of class \code{Prior} specifying prior distribution for the baseline outcome. See
+\code{Details} for more information.}
 
-\item{std_dev_prior}{\code{Prior}. Object of class \code{Prior}
-specifying prior distribution for the standard deviation of the outcome distribution (i.e. "sigma").}
+\item{std_dev_prior}{\code{Prior}. Object of class \code{Prior} specifying prior distribution for the standard deviation of the
+outcome distribution (i.e. "sigma").}
 
 \item{weight_var}{character. Optional name of variable in model matrix for weighting the log likelihood.}
 }
@@ -33,15 +31,13 @@ Normal Outcome Distribution
 \details{
 \subsection{Baseline Prior}{
 
-The \code{baseline_prior} argument specifies the prior distribution for the
-intercept of the linear model. The interpretation of the \code{baseline_prior} differs
-slightly between borrowing methods selected.
+The \code{baseline_prior} argument specifies the prior distribution for the intercept of the linear model. The
+interpretation of the \code{baseline_prior} differs slightly between borrowing methods selected.
 \itemize{
-\item \emph{Dynamic borrowing using \code{borrowing_hierarchical_commensurate()}}: the \code{baseline_prior} for Bayesian Dynamic Borrowing
-refers to the intercept of the external control arm.
-\item \emph{Full borrowing} or \emph{No borrowing} using \code{borrowing_full()} or \code{borrowing_none()}: the \code{baseline_prior} for
-these borrowing methods refers to the intercept for the
-internal control arm.
+\item \emph{Dynamic borrowing using \code{borrowing_hierarchical_commensurate()}}: the \code{baseline_prior} for
+Bayesian Dynamic Borrowing refers to the intercept of the external control arm.
+\item \emph{Full borrowing} or \emph{No borrowing} using \code{borrowing_full()} or \code{borrowing_none()}: the
+\code{baseline_prior} for these borrowing methods refers to the intercept for the internal control arm.
 }
 }
 }

--- a/man/outcome_surv_pem.Rd
+++ b/man/outcome_surv_pem.Rd
@@ -26,7 +26,7 @@ See \code{Details} for more information.}
 \item{cut_points}{numeric. Vector of internal cut points for the piecewise exponential model. Note: the choice of
 cut points will impact the amount of borrowing between arms when dynamic borrowing methods are selected. It is
 recommended to choose cut points that contain an equal number of events within each interval. Please include only internal
-cut points in the vector. For instance, for cut points of [0, 15], (15, 20], (20, Inf], the vector should be c(15, 20).
+cut points in the vector. For instance, for cut points of [0, 15], (15, 20], (20, Inf), the vector should be c(15, 20).
 If you pass cut-points beyond the follow-up of the data, you will receive an informative warning when calling
 \code{create_analysis_object()} and these cut points will be ignored.}
 }

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -166,3 +166,52 @@ test_that("variable_dictionary includes shape parameter for Weibull PH", {
     )
   )
 })
+
+
+test_that("variable_dictionary works for normal outcome and no borrowing", {
+  object <- psborrow2:::.analysis_obj(
+    data_matrix = cbind(example_matrix, outcome = runif(500)),
+    outcome = outcome_cont_normal(
+      continuous_var = "outcome",
+      baseline_prior = prior_normal(0, 100),
+      std_dev_prior = prior_half_cauchy(1, 5)
+    ),
+    borrowing = borrowing_full("ext"),
+    treatment = treatment_details("trt", prior_normal(0, 1000))
+  )
+  result <- variable_dictionary(object)
+  expect_equal(
+    result,
+    data.frame(
+      Stan_variable = c("alpha", "beta_trt"),
+      Description = c("intercept", "treatment effect")
+    )
+  )
+})
+
+test_that("variable_dictionary works for normal outcome with BDB borrowing", {
+  object <- psborrow2:::.analysis_obj(
+    data_matrix = cbind(example_matrix, outcome = runif(500)),
+    outcome = outcome_cont_normal(
+      continuous_var = "outcome",
+      baseline_prior = prior_normal(0, 100),
+      std_dev_prior = prior_half_cauchy(1, 5)
+    ),
+    borrowing = borrowing_hierarchical_commensurate(
+      ext_flag_col = "ext",
+      tau_prior = prior_gamma(0.001, 0.001)
+    ),
+    treatment = treatment_details("trt", prior_normal(0, 1000))
+  )
+  result <- variable_dictionary(object)
+  expect_equal(
+    result,
+    data.frame(
+      Stan_variable = c("tau", "alpha[1]", "alpha[2]", "beta_trt"),
+      Description = c(
+        "commensurability parameter", "intercept, internal",
+        "intercept, external", "treatment effect"
+      )
+    )
+  )
+})


### PR DESCRIPTION
Fixes #310

 - Don't report exp(treatment effect) for continuous outcomes
 - Fix stan models:
   - remove Z and tau from full/no borrowing model
   - fix Z, alpha, tau definitions in BDB model
 - add effective tests